### PR TITLE
Update minimum PyMongo version

### DIFF
--- a/datalake_api/requirements.txt
+++ b/datalake_api/requirements.txt
@@ -3,7 +3,7 @@ connexion[swagger-ui]
 python_dateutil == 2.6.0
 setuptools
 swagger-ui-bundle
-pymongo == 4.5.0
+pymongo == 4.6.3
 urllib3 == 1.26.19
 dl-tui @ git+https://github.com/Eurocc-Italy/dl_tui
 boto3

--- a/datalake_api/setup.py
+++ b/datalake_api/setup.py
@@ -18,7 +18,7 @@ REQUIRES = [
     "python_dateutil == 2.6.0",
     "setuptools",
     "swagger-ui-bundle",
-    "pymongo == 4.5.0",
+    "pymongo == 4.6.3",
     "urllib3 == 1.26.19",
     "dl_tui @ git+https://github.com/Eurocc-Italy/dl_tui",
     "boto3",


### PR DESCRIPTION
Required `pymongo` version has been updated from `4.5.0` to `4.6.3`

Tests were carried out launching commands using the TUI and API on the same pymongo version, everything looks okay.

Closes #3 