### PR TITLE
Forcing boto3=1.35 and python-dateutil 2.7

### DIFF
--- a/datalake_api/requirements.txt
+++ b/datalake_api/requirements.txt
@@ -1,12 +1,12 @@
 connexion == 2.14.2
 connexion[swagger-ui] 
-python_dateutil == 2.6.0
+boto3 == 1.35.0
+python_dateutil == 2.7.0
 setuptools
 swagger-ui-bundle
 pymongo == 4.6.3
 urllib3 == 1.26.19
 dl-tui @ git+https://github.com/Eurocc-Italy/dl_tui
-boto3
 python-decouple
 python-dotenv
 python-jose


### PR DESCRIPTION
`boto3` versions later than 1.35 can fail with some 3rd-party S3 services (such as Cineca's G100). Moreover, for Python 3.10+, the current `python-dateutil 2.6.0` is not supported, resulting in errors.

Fixes #8 